### PR TITLE
- Support Classes and Annotations in docset

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -17,13 +17,13 @@ To build the tool, you will need to run `./gradlew shadowJar`.
 
 Simple example:
 
-    java -jar build/dash/libs/dash-0.0.1-all.jar --output-dir build/generated-docs --name foo dash/src/main/java`
+    java -jar build/dash/libs/dash-0.0.2-SNAPSHOT-all.jar --output-dir build/generated-docs --name foo dash/src/main/java
 
 Running this will generate a file `build/generated-docs/foo.docset`, you can simply add this to Dash. 
 
 Detailed example:
 
-    java -jar build/dash/libs/dash-0.0.1-all.jar --output-dir build/generated-docs/gradle3 --name gradle  --index ~/Downloads/gradle-2.5/docs/dsl  `find ~/Downloads/gradle-2.5/src -type d -maxdepth 1 -mindepth 1 -exec echo -n "{} " \;`
+    java -jar build/dash/libs/dash-0.0.2-SNAPSHOT-all.jar --output-dir build/generated-docs/gradle3 --name gradle  --index ~/Downloads/gradle-2.5/docs/dsl  `find ~/Downloads/gradle-2.5/src -type d -maxdepth 1 -mindepth 1 -exec echo -n "{} " \;`
 
 This will take about 8 min to run. The find command will get the source root of all the folders, making the dsl links work.
 

--- a/README.markdown
+++ b/README.markdown
@@ -2,9 +2,26 @@
 
 This project allows for you to generate documentation from project source. This project uses a modified groovydoc page to remove the navigation and keep the 'look and feel' the same across pages.
 
-To build the tool, you will need to run `./gradlew shadowJar`. Once that runs, would execute the jar that get generated. A simple example is `java -jar build/dash/libs/dash-0.0.1-all.jar --output-dir build/generated-docs --name foo dash/src/main/java`
+To build the tool, you will need to run `./gradlew shadowJar`. 
 
-Running this will generate a file `build/generated-docs/foo.docset`, you can simply add this to Dash. A more complicated used to generate the gradle docset is 
+## Usage
+
+    java -jar dash-<version>-all.jar <options> <src-directories>
+    
+### Options
+
+* --output-dir \<dir\>   : Directory to create the docset in
+* --name \<name\>        : Name of the docset
+* --index \<index\>      : Index to start with
+* src-directories        : Directories to search for source files
+
+Simple example:
+
+    java -jar build/dash/libs/dash-0.0.1-all.jar --output-dir build/generated-docs --name foo dash/src/main/java`
+
+Running this will generate a file `build/generated-docs/foo.docset`, you can simply add this to Dash. 
+
+Detailed example:
 
     java -jar build/dash/libs/dash-0.0.1-all.jar --output-dir build/generated-docs/gradle3 --name gradle  --index ~/Downloads/gradle-2.5/docs/dsl  `find ~/Downloads/gradle-2.5/src -type d -maxdepth 1 -mindepth 1 -exec echo -n "{} " \;`
 

--- a/build.gradle
+++ b/build.gradle
@@ -19,5 +19,6 @@ allprojects {
   buildDir = rootProject.file("build/${project.name}")
   
   group = 'io.ehdev.dash'
-  version = '0.0.1'
+  version = '0.0.2-SNAPSHOT'
+
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,19 @@
 allprojects {
 
-  apply plugin: 'groovy'
+  apply plugin:'groovy'
+
+
+  configurations {
+    deployerJars
+  }
 
   repositories {
     mavenCentral()
+  }
+
+  dependencies {
+    // deployerJars "org.apache.maven.wagon:wagon-ssh:2.2"
+    deployerJars "org.apache.maven.wagon:wagon-http:2.2"
   }
 
   buildDir = rootProject.file("build/${project.name}")

--- a/dash/build.gradle
+++ b/dash/build.gradle
@@ -4,6 +4,8 @@ plugins {
     id 'com.github.johnrengelman.shadow' version '1.2.2'
 }
 
+apply plugin:'maven'
+
 mainClassName = 'io.ehdev.dash.MainClass'
 
 dependencies {
@@ -22,4 +24,21 @@ dependencies {
 
 shadowJar {
     mergeGroovyExtensionModules()
+}
+
+
+uploadShadow {
+    dependsOn test
+    // set in ~/.gradle/gradle.properties
+    assert repoUser && repoPassword && repoUrl
+    def isSnapshot = version ==~ /.*SNAPSHOT.*/
+    def repo = isSnapshot ? "${repoUrl}/libs-snapshots-local" : "${repoUrl}/libs-releases-local"
+    repositories {
+        mavenDeployer {
+            configuration = configurations.deployerJars
+            repository(url:repo) {
+                authentication(userName:repoUser, password:repoPassword)
+            }
+        }
+    }
 }

--- a/dash/src/main/groovy/io/ehdev/dash/parser/ClassDocParser.groovy
+++ b/dash/src/main/groovy/io/ehdev/dash/parser/ClassDocParser.groovy
@@ -28,9 +28,12 @@ class ClassDocParser {
             }
             def filename = 'groovydoc/' + groovyClassDoc.getFullPathName() + '.html'
 
+            forDocClass(groovyClassDoc, ObjectType.CLASS, filename)
+
             forEachMember(groovyClassDoc.fields(), ObjectType.FIELD, filename)
             forEachMember(groovyClassDoc.enumConstants(), ObjectType.ENUM, filename)
             forEachMember(groovyClassDoc.properties(), ObjectType.PROPERTY, filename)
+            forEachAnnotation(groovyClassDoc.annotations(), ObjectType.ANNOTATION, filename)
 
             forEachExecutable(groovyClassDoc.methods(), ObjectType.METHOD, filename)
             forEachExecutable(groovyClassDoc.constructors(), ObjectType.CONSTRUCTOR, filename)
@@ -44,6 +47,17 @@ class ClassDocParser {
                 dashSql.insert(name, property, "${filename}#${name}")
             }
         }
+    }
+
+    private void forEachAnnotation(GroovyAnnotationRef[] annotations, ObjectType property, String filename) {
+        for(GroovyAnnotationRef annotationRef: annotations) {
+            dashSql.insert(annotationRef.name(), property, "${filename}#${annotationRef.name()}" )
+        }
+    }
+
+    private void forDocClass(GroovyClassDoc doc, ObjectType property, String filename) {
+        dashSql.insert(doc.name(), property, "${filename}")
+
     }
 
     private void forEachMember(GroovyMemberDoc[] members, ObjectType property, String filename) {

--- a/dash/src/test/groovy/io/ehdev/dash/DashDocsetCreatorTest.groovy
+++ b/dash/src/test/groovy/io/ehdev/dash/DashDocsetCreatorTest.groovy
@@ -4,6 +4,8 @@ import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
 
+import javax.imageio.stream.ImageInputStream
+
 class DashDocsetCreatorTest extends Specification {
     @Rule
     TemporaryFolder temporaryFolder
@@ -20,7 +22,7 @@ class DashDocsetCreatorTest extends Specification {
         def dashCreator = new DashDocsetCreator([new File('src/main/groovy')], destination)
 
         when:
-        dashCreator.createDashDocset()
+        dashCreator.createDashDocset(null,"")
 
         then:
         noExceptionThrown()


### PR DESCRIPTION
Thanks for the tool. Here is a slight enhancement I use to generate docset for my Grails projects. In your version, Classes and Annotations were not included in the docset. This change adds it and:

 - Test fixed
 - Updated README
 - Added maven deployment support (currently using my Artifactory)
